### PR TITLE
Fix formatting and typos in Reflection 3

### DIFF
--- a/_posts/2016-09-22-ignobel.md
+++ b/_posts/2016-09-22-ignobel.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Want to win an Ig Nobel? Here are some suggestions.
+title: Want to win an Ig Nobel? Here are some suggestions
 author: neuroamanda
 ---
 
@@ -13,10 +13,11 @@ The hard part is finding research about these obscure, fleeting puzzlings.
 My quest often goes unfulfilled.
 
 Luckily, there is a prize that rewards researchers who conduct just these kinds of investigations.
-For figuring out things like [why woodpeckers don't get headaches](http://www.ucdmc.ucdavis.edu/welcome/features/20061011_ig_nobel_schwab/index.html), or how to [un-boil an egg](https://dx.doi.org/10.1002%2Fcbic.201402427), or [whether banana skins actually make you slip](https://dx.doi.org/10.2474%2Ftrol.7.147), intrepid scientists are awarded the [Ig Nobel Prize](http://www.improbable.com/ig/), the down-to-earth and tongue-in-cheek Nobel Prize spoof that is surprisingly revealing about what counts as relatable science and how the scientific method can be brought to bear on the humorous, the smutty, and the bizarre.
+For figuring out things like [why woodpeckers don't get headaches](http://www.ucdmc.ucdavis.edu/welcome/features/20061011_ig_nobel_schwab/index.html), or how to [un-boil an egg](https://dx.doi.org/10.1002%2Fcbic.201402427), or [whether banana skins actually make you slip](https://dx.doi.org/10.2474%2Ftrol.7.147), intrepid scientists are awarded the [Ig Nobel Prize](http://www.improbable.com/ig/), the down-to-earth and tongue-in-cheek Nobel Prize spoof that is surprisingly revealing about what counts as relatable science and how the scientific method can be brought to bear on the humorous, the smutty and the bizarre.
 (The 2016 Ig Nobel ceremony on September 22 is being [livestreamed here](http://www.improbable.com/ig/2016/).)
 
 In no particular order, here are some Ig Nobel-worthy contenders, as proposed by the Twitterverse:
+
 * [When zombies attack: mathematical modelling of an outbreak of zombie infection](https://www.math.upenn.edu/~ted/203S10/Projects/Zombies/Zombies.pdf) [PDF] (Related: [A mathematical model of Bieber Fever: the most infectious disease of our time?](http://mysite.science.uottawa.ca/rsmith43/BieberFever.pdf) [PDF])
 * [The ethics of human-chicken relationships in video games: the origins of the digital chicken](http://dl.acm.org/citation.cfm?id=2874254) (chicken-related research has scored at least four Ig Nobels so far)
 * [Misperceiving bullshit as profound is associated with favorable views of Cruz, Rubio, Trump and conservatism](http://journals.plos.org/plosone/article?id=10.1371%2Fjournal.pone.0153419)


### PR DESCRIPTION
Tested locally and Jekyll seems to build the bullets correctly without the space. But this should fix it.

Also removed the full stop at the end of the title and removed the serial comma from par 2, per @neuroamanda's request.
